### PR TITLE
Full path for JsSuccess

### DIFF
--- a/src/main/scala/julienrf/variants/Variants.scala
+++ b/src/main/scala/julienrf/variants/Variants.scala
@@ -78,7 +78,7 @@ object Variants {
         if (!variant.isModuleClass) {
           cq"""${variant.name.decodedName.toString} => play.api.libs.json.Json.fromJson(json)(play.api.libs.json.Json.reads[$variant])"""
         } else {
-          cq"""${variant.name.decodedName.toString} => JsSuccess(${newTermName(variant.name.decodedName.toString)})"""
+          cq"""${variant.name.decodedName.toString} => play.api.libs.json.JsSuccess(${newTermName(variant.name.decodedName.toString)})"""
         }
       }
       val reads =

--- a/src/test/scala/julienrf/variants/VariantsSpec.scala
+++ b/src/test/scala/julienrf/variants/VariantsSpec.scala
@@ -1,8 +1,7 @@
 package julienrf.variants
 
 import org.specs2.mutable.Specification
-import play.api.libs.json._
-import play.api.libs.json.JsSuccess
+import play.api.libs.json.{Json,Format}
 
 object VariantsSpec extends Specification {
 


### PR DESCRIPTION
Prevent error when the client code does not import JsSuccess.
