### PR TITLE
Implement the "own" derived

### DIFF
--- a/src/main/scala/julienrf/json/derived/package.scala
+++ b/src/main/scala/julienrf/json/derived/package.scala
@@ -25,4 +25,19 @@ package object derived {
 
   }
 
+  object own {
+
+    def reads[A](typeName: Reads[String], typeNameTransformer: String => String)(implicit derivedReads: Lazy[DerivedReads[A]]): Reads[A] =
+      derivedReads.value.reads(TypeTagReads.own(typeName, typeNameTransformer))
+
+    def owrites[A](typeName: OWrites[String], typeNameTransformer: String => String)(implicit derivedOWrites: Lazy[DerivedOWrites[A]]): OWrites[A] =
+      derivedOWrites.value.owrites(TypeTagOWrites.own(typeName, typeNameTransformer))
+
+    def oformat[A](typeName: OFormat[String], typeNameTransformer: String => String)(implicit derivedReads: Lazy[DerivedReads[A]], derivedOWrites: Lazy[DerivedOWrites[A]]): OFormat[A] =
+      OFormat(
+        derivedReads.value.reads(TypeTagReads.own(typeName, typeNameTransformer)),
+        derivedOWrites.value.owrites(TypeTagOWrites.own(typeName, typeNameTransformer))
+      )
+  }
+
 }

--- a/src/main/scala/julienrf/json/derived/typetags.scala
+++ b/src/main/scala/julienrf/json/derived/typetags.scala
@@ -1,6 +1,6 @@
 package julienrf.json.derived
 
-import play.api.libs.json.{Reads, Json, OWrites, __}
+import play.api.libs.json._
 
 trait TypeTagOWrites {
   def owrites[A](typeName: String, owrites: OWrites[A]): OWrites[A]
@@ -21,6 +21,12 @@ object TypeTagOWrites {
     }
 
 
+  def own(tagOwrites: OWrites[String], typeNameTransformer: String => String): TypeTagOWrites =
+    new TypeTagOWrites {
+      def owrites[A](typeName: String, owrites: OWrites[A]): OWrites[A] =
+        OWrites[A](a => tagOwrites.writes(typeNameTransformer(typeName)) ++ owrites.writes(a))
+    }
+
 }
 
 trait TypeTagReads {
@@ -39,6 +45,12 @@ object TypeTagReads {
     new TypeTagReads {
       def reads[A](typeName: String, reads: Reads[A]): Reads[A] =
         tagReads.filter(_ == typeName).flatMap(_ => reads)
+    }
+
+  def own(tagReads: Reads[String], typeNameTransformer: String => String): TypeTagReads =
+    new TypeTagReads {
+      def reads[A](typeName: String, reads: Reads[A]): Reads[A] =
+        tagReads.filter(_ == typeNameTransformer(typeName)).flatMap(_ => reads)
     }
 
 }


### PR DESCRIPTION
What do you thinks about my `own` (the name is not so great) derived ?
It could simplify the implementation of specific "codecs" (I don't know how to call that)

Typically my use case is: I have a "flat" object but the value of the `type` does not correspond to any class. So with the `typeNameTransformer` I can transform the value of `type` to match my class name.
Example:

```json
{
    "type": "address",
    "line1": ...
}
```
this ADT:

```scala
sealed trait Location { val `type`: String }
case class CityLocation(zip_code: String, override val `type`: String = "city") extends Location
case class AddressLocation(line1: String, override val `type`: String = "address") extends Location
```

So I will write:
```scala
object Location {
    implicit val write: OFormat[Location] = own.oformat((__ \ "type").format[String], (value: String) => s"${value.capitalize}Location")
}
```

Maybe I don't really understand how your lib work, so if what I say does not have sense, do not hesitate to tell me ;)

The code is not necessarily correct for now and there are not tests too but, for now, it's just to validate the idea.
