### PR TITLE
Allow case class member names to be customized when deriving the codecs

### DIFF
--- a/src/main/scala/julienrf/json/derived/DerivedOWrites.scala
+++ b/src/main/scala/julienrf/json/derived/DerivedOWrites.scala
@@ -19,6 +19,7 @@ trait DerivedOWritesInstances extends DerivedOWritesInstances1 {
 
   implicit def owritesLabelledHListOpt[A, K <: Symbol, H, T <: HList](implicit
     fieldName: Witness.Aux[K],
+    adaptedName: FieldAdapter[K],
     owritesH: Lazy[Writes[H]],
     owritesT: Lazy[DerivedOWrites[T]]
   ): DerivedOWrites[FieldType[K, Option[H]] :: T] =
@@ -27,7 +28,7 @@ trait DerivedOWritesInstances extends DerivedOWritesInstances1 {
         OWrites[FieldType[K, Option[H]] :: T] { case maybeH :: t =>
           val maybeField: Map[String, JsValue] =
             (maybeH: Option[H]) match {
-              case Some(h) => Map(fieldName.value.name -> owritesH.value.writes(h))
+              case Some(h) => Map(adaptedName.name -> owritesH.value.writes(h))
               case None => Map.empty
             }
           JsObject(maybeField ++ owritesT.value.owrites(tagOwrites).writes(t).value)
@@ -41,6 +42,7 @@ trait DerivedOWritesInstances extends DerivedOWritesInstances1 {
 
   implicit def owritesCoproduct[K <: Symbol, L, R <: Coproduct](implicit
     typeName: Witness.Aux[K],
+    adaptedName: FieldAdapter[K],
     owritesL: Lazy[DerivedOWrites[L]],
     owritesR: Lazy[DerivedOWrites[R]]
   ): DerivedOWrites[FieldType[K, L] :+: R] =
@@ -58,13 +60,14 @@ trait DerivedOWritesInstances1 extends DerivedOWritesInstances2 {
 
   implicit def owritesLabelledHList[A, K <: Symbol, H, T <: HList](implicit
     fieldName: Witness.Aux[K],
+    adaptedName: FieldAdapter[K],
     owritesH: Lazy[Writes[H]],
     owritesT: Lazy[DerivedOWrites[T]]
   ): DerivedOWrites[FieldType[K, H] :: T] =
     new DerivedOWrites[FieldType[K, H] :: T] {
       def owrites(tagOwrites: TypeTagOWrites) =
         OWrites[FieldType[K, H] :: T] { case h :: t =>
-          JsObject(Map(fieldName.value.name -> owritesH.value.writes(h)) ++ owritesT.value.owrites(tagOwrites).writes(t).value)
+          JsObject(Map(adaptedName.name -> owritesH.value.writes(h)) ++ owritesT.value.owrites(tagOwrites).writes(t).value)
         }
     }
 

--- a/src/main/scala/julienrf/json/derived/DerivedReads.scala
+++ b/src/main/scala/julienrf/json/derived/DerivedReads.scala
@@ -19,6 +19,7 @@ trait DerivedReadsInstances extends DerivedReadsInstances1 {
 
   implicit def readsCoProduct[K <: Symbol, L, R <: Coproduct](implicit
     typeName: Witness.Aux[K],
+    adaptedName: FieldAdapter[K],
     readL: Lazy[DerivedReads[L]],
     readR: Lazy[DerivedReads[R]]
   ): DerivedReads[FieldType[K, L] :+: R] =
@@ -36,13 +37,14 @@ trait DerivedReadsInstances extends DerivedReadsInstances1 {
 
   implicit def readsLabelledHListOpt[K <: Symbol, H, T <: HList](implicit
     fieldName: Witness.Aux[K],
+    adaptedName: FieldAdapter[K],
     readH: Lazy[Reads[H]],
     readT: Lazy[DerivedReads[T]]
   ): DerivedReads[FieldType[K, Option[H]] :: T] =
     new DerivedReads[FieldType[K, Option[H]] :: T] {
       def reads(tagReads: TypeTagReads) =
         Reads.applicative.apply(
-          (__ \ fieldName.value.name).readNullable(readH.value).map {
+          (__ \ adaptedName.name).readNullable(readH.value).map {
             h => { (t: T) => field[K](h) :: t }
           },
           readT.value.reads(tagReads)
@@ -55,13 +57,14 @@ trait DerivedReadsInstances1 extends DerivedReadsInstances2 {
 
   implicit def readsLabelledHList[K <: Symbol, H, T <: HList](implicit
     fieldName: Witness.Aux[K],
+    adaptedName: FieldAdapter[K],
     readH: Lazy[Reads[H]],
     readT: Lazy[DerivedReads[T]]
   ): DerivedReads[FieldType[K, H] :: T] =
     new DerivedReads[FieldType[K, H] :: T] {
       def reads(tagReads: TypeTagReads) =
         Reads.applicative.apply(
-          (__ \ fieldName.value.name).read(readH.value).map {
+          (__ \ adaptedName.name).read(readH.value).map {
             h => { (t: T) => field[K](h) :: t }
           },
           readT.value.reads(tagReads)

--- a/src/main/scala/julienrf/json/derived/FieldAdapter.scala
+++ b/src/main/scala/julienrf/json/derived/FieldAdapter.scala
@@ -1,0 +1,40 @@
+package julienrf.json.derived
+
+import shapeless.Witness
+
+class FieldAdapter[K <: Symbol](w: Witness.Aux[K], a: Adapter) {
+  val name = a(w.value.name)
+}
+
+
+object FieldAdapter {
+  implicit def witnessAdapter[K <: Symbol](implicit w: Witness.Aux[K], a: Adapter): FieldAdapter[K] = {
+    new FieldAdapter[K](w, a)
+  }
+}
+
+trait Adapter extends (String => String)
+
+object Adapter {
+  private def toSnakeCase(s: String): String =
+    s.foldLeft(new StringBuilder) {
+      case (s, c) if Character.isUpperCase(c) && s.nonEmpty => s append "_" append (Character toLowerCase c)
+      case (s, c) => s append c
+    }.toString
+
+  def snakeCase = new Adapter {
+    override def apply(v1: String): String = toSnakeCase(v1)
+  }
+
+  def identity = new Adapter {
+    override def apply(v1: String): String = v1
+  }
+
+  implicit val default = identity
+
+  def apply(f: (String => String)): Adapter = new Adapter {
+    override def apply(v1: String): String = f(v1)
+  }
+
+
+}

--- a/src/test/scala/julienrf/json/derived/FieldAdapterSuite.scala
+++ b/src/test/scala/julienrf/json/derived/FieldAdapterSuite.scala
@@ -1,0 +1,81 @@
+package julienrf.json.derived
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.FeatureSpec
+import org.scalatest.prop.Checkers
+import play.api.libs.json._
+
+class FieldAdapterSuite extends FeatureSpec with Checkers {
+
+  feature("use camelCase as the default casing for field names") {
+
+    scenario("product type") {
+      case class Foo(sC: String, iC: Int)
+      implicit val fooArbitrary: Arbitrary[(Foo, JsValue)] =
+        Arbitrary(for (s <- Gen.alphaStr; i <- arbitrary[Int]) yield (Foo(s, i), Json.obj("sC" -> s, "iC" -> i)))
+      implicit val fooFormat: OFormat[Foo] = oformat
+      jsonIdentityLaw[Foo]
+    }
+
+
+    scenario("sum types") {
+      sealed trait Foo
+      case class Bar(xC: Int) extends Foo
+      case class Baz(sC: String) extends Foo
+      case object Bah extends Foo
+
+      implicit val fooArbitrary: Arbitrary[(Foo, JsValue)] =
+        Arbitrary(
+          Gen.oneOf(
+            arbitrary[Int].map(i => (Bar(i), Json.obj("xC" -> i, "type" -> "Bar"))),
+            Gen.alphaStr.map(s => (Baz(s), Json.obj("sC" -> s, "type" -> "Baz"))),
+            Gen.const((Bah, Json.obj("type" -> "Bah"))
+            )
+          ))
+
+      implicit val fooFormat: OFormat[Foo] = flat.oformat((__ \ "type").format[String])
+      jsonIdentityLaw[Foo]
+
+    }
+
+  }
+
+  feature("customize the casing for field names") {
+    implicit val snake = Adapter.snakeCase
+
+    scenario("product type") {
+      case class Foo(sC: String, iC: Int)
+      implicit val fooArbitrary: Arbitrary[(Foo, JsValue)] =
+        Arbitrary(for (s <- Gen.alphaStr; i <- arbitrary[Int]) yield (Foo(s, i), Json.obj("s_c" -> s, "i_c" -> i)))
+      implicit val fooFormat: OFormat[Foo] = oformat
+      jsonIdentityLaw[Foo]
+    }
+
+    scenario("sum types") {
+      sealed trait Foo
+      case class Bar(xC: Int) extends Foo
+      case class Baz(sC: String) extends Foo
+      case object Bah extends Foo
+
+      implicit val fooArbitrary: Arbitrary[(Foo, JsValue)] =
+        Arbitrary(
+          Gen.oneOf(
+            arbitrary[Int].map(i => (Bar(i), Json.obj("x_c" -> i, "type" -> "Bar"))),
+            Gen.alphaStr.map(s => (Baz(s), Json.obj("s_c" -> s, "type" -> "Baz"))),
+            Gen.const((Bah, Json.obj("type" -> "Bah"))
+            )
+          ))
+
+      implicit val fooFormat: OFormat[Foo] = flat.oformat((__ \ "type").format[String])
+      jsonIdentityLaw[Foo]
+    }
+  }
+
+
+  def jsonIdentityLaw[A](implicit reads: Reads[A], owrites: OWrites[A], arbA: Arbitrary[(A, JsValue)]): Unit =
+    check((a: (A, JsValue)) => {
+      reads.reads(a._2).fold(_ => false, r => r == a._1 && owrites.writes(r) == a._2)
+    })
+
+}


### PR DESCRIPTION
This is to allow for case class members to be transformed, adapting to custom fields casing in the json.
For example it can be used to convert field names to snake case.

I consider it a first draft, to get some ideas around the possible solution, but it's already working and have added some tests for it.

