### PR TITLE
Redesign the configurability of the derived serializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,21 @@ For instance, you might want to represent the `Bar("quux", 42)` value as the fol
 
 Here, the type information is flattened with the `Bar` members.
 
-You can do so by using the methods in the `derived.flat` object:
+You can do so by using a “FlatTypeTagOFormat”:
 
 ~~~ scala
-implicit val fooOWrites: OWrites[Foo] =
-  derived.flat.owrites((__ \ "type").write[String])
+import julienrf.json.derived.FlatTypeTagOFormat
+
+object FlatFormat extends FlatTypeTagOFormat {
+  val tagOFormat: OFormat[String] = (__ \ "type").format
+}
+~~~
+
+And then:
+
+~~~ scala
+import FlatFormat._
+implicit val fooOWrites: OWrites[Foo] = derived.oformat
 ~~~
 
 In case you need even more control, you can still implement your own `TypeTagOWrites` and `TypeTagReads`.

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ enablePlugins(GitVersioning)
 scalaVersion := "2.11.8"
 
 libraryDependencies ++= Seq(
-  "com.chuusai" %% "shapeless" % "2.3.0",
+  "com.chuusai" %% "shapeless" % "2.3.1",
   "org.scalatest" %% "scalatest" % "2.2.6" % Test,
   "org.scalacheck" %% "scalacheck" % "1.12.5" % Test,
   "com.typesafe.play" %% "play-json" % "2.5.2"

--- a/src/main/scala/julienrf/json/derived/DerivedOWrites.scala
+++ b/src/main/scala/julienrf/json/derived/DerivedOWrites.scala
@@ -5,7 +5,7 @@ import shapeless.labelled.FieldType
 import shapeless.{:+:, ::, CNil, Coproduct, HList, HNil, Inl, Inr, LabelledGeneric, Lazy, Witness}
 
 trait DerivedOWrites[-A] {
-  def owrites(tagOwrites: TypeTagOWrites): OWrites[A]
+  def owrites: OWrites[A]
 }
 
 object DerivedOWrites extends DerivedOWritesInstances
@@ -14,7 +14,7 @@ trait DerivedOWritesInstances extends DerivedOWritesInstances1 {
 
   implicit val owritesHNil: DerivedOWrites[HNil] =
     new DerivedOWrites[HNil] {
-      def owrites(tagOwrites: TypeTagOWrites) = OWrites[HNil] { _ => Json.obj() }
+      val owrites = OWrites[HNil] { _ => Json.obj() }
     }
 
   implicit def owritesLabelledHListOpt[A, K <: Symbol, H, T <: HList](implicit
@@ -23,31 +23,32 @@ trait DerivedOWritesInstances extends DerivedOWritesInstances1 {
     owritesT: Lazy[DerivedOWrites[T]]
   ): DerivedOWrites[FieldType[K, Option[H]] :: T] =
     new DerivedOWrites[FieldType[K, Option[H]] :: T] {
-      def owrites(tagOwrites: TypeTagOWrites) =
+      val owrites =
         OWrites[FieldType[K, Option[H]] :: T] { case maybeH :: t =>
           val maybeField: Map[String, JsValue] =
             (maybeH: Option[H]) match {
               case Some(h) => Map(fieldName.value.name -> owritesH.value.writes(h))
               case None => Map.empty
             }
-          JsObject(maybeField ++ owritesT.value.owrites(tagOwrites).writes(t).value)
+          JsObject(maybeField ++ owritesT.value.owrites.writes(t).value)
         }
     }
 
   implicit val owritesCNil: DerivedOWrites[CNil] =
     new DerivedOWrites[CNil] {
-      def owrites(tagOwrites: TypeTagOWrites): OWrites[CNil] = sys.error("No JSON representation of CNil")
+      def owrites: OWrites[CNil] = sys.error("No JSON representation of CNil")
     }
 
   implicit def owritesCoproduct[K <: Symbol, L, R <: Coproduct](implicit
     typeName: Witness.Aux[K],
     owritesL: Lazy[DerivedOWrites[L]],
-    owritesR: Lazy[DerivedOWrites[R]]
+    owritesR: Lazy[DerivedOWrites[R]],
+    typeTagOWrites: TypeTagOWrites
   ): DerivedOWrites[FieldType[K, L] :+: R] =
     new DerivedOWrites[FieldType[K, L] :+: R] {
-      def owrites(tagOwrites: TypeTagOWrites) = OWrites[FieldType[K, L] :+: R] {
-        case Inl(l) => tagOwrites.owrites(typeName.value.name, owritesL.value.owrites(tagOwrites)).writes(l)
-        case Inr(r) => owritesR.value.owrites(tagOwrites).writes(r)
+      val owrites = OWrites[FieldType[K, L] :+: R] {
+        case Inl(l) => typeTagOWrites.owrites(typeName.value.name, owritesL.value.owrites).writes(l)
+        case Inr(r) => owritesR.value.owrites.writes(r)
       }
     }
 
@@ -62,9 +63,9 @@ trait DerivedOWritesInstances1 extends DerivedOWritesInstances2 {
     owritesT: Lazy[DerivedOWrites[T]]
   ): DerivedOWrites[FieldType[K, H] :: T] =
     new DerivedOWrites[FieldType[K, H] :: T] {
-      def owrites(tagOwrites: TypeTagOWrites) =
+      val owrites =
         OWrites[FieldType[K, H] :: T] { case h :: t =>
-          JsObject(Map(fieldName.value.name -> owritesH.value.writes(h)) ++ owritesT.value.owrites(tagOwrites).writes(t).value)
+          JsObject(Map(fieldName.value.name -> owritesH.value.writes(h)) ++ owritesT.value.owrites.writes(t).value)
         }
     }
 
@@ -77,8 +78,8 @@ trait DerivedOWritesInstances2 {
     derivedOWrites: Lazy[DerivedOWrites[R]]
   ): DerivedOWrites[A] =
     new DerivedOWrites[A] {
-      def owrites(tagOwrites: TypeTagOWrites) =
-        OWrites.contravariantfunctorOWrites.contramap(derivedOWrites.value.owrites(tagOwrites), gen.to)
+      lazy val owrites =
+        OWrites.contravariantfunctorOWrites.contramap(derivedOWrites.value.owrites, gen.to)
     }
 
 }

--- a/src/main/scala/julienrf/json/derived/DerivedReads.scala
+++ b/src/main/scala/julienrf/json/derived/DerivedReads.scala
@@ -5,7 +5,7 @@ import shapeless.labelled.{FieldType, field}
 import shapeless.{::, HList, HNil, LabelledGeneric, Lazy, Witness, Coproduct, :+:, Inr, Inl, CNil}
 
 trait DerivedReads[A] {
-  def reads(tagReads: TypeTagReads): Reads[A]
+  def reads: Reads[A]
 }
 
 object DerivedReads extends DerivedReadsInstances
@@ -14,24 +14,25 @@ trait DerivedReadsInstances extends DerivedReadsInstances1 {
 
   implicit val readsCNil: DerivedReads[CNil] =
     new DerivedReads[CNil] {
-      def reads(tagReads: TypeTagReads) = Reads[CNil] { _ => JsError("error.sealed.trait") }
+      val reads = Reads[CNil] { _ => JsError("error.sealed.trait") }
     }
 
   implicit def readsCoProduct[K <: Symbol, L, R <: Coproduct](implicit
     typeName: Witness.Aux[K],
     readL: Lazy[DerivedReads[L]],
-    readR: Lazy[DerivedReads[R]]
+    readR: Lazy[DerivedReads[R]],
+    typeTagReads: TypeTagReads
   ): DerivedReads[FieldType[K, L] :+: R] =
     new DerivedReads[FieldType[K, L] :+: R] {
-      def reads(tagReads: TypeTagReads) =
-        tagReads.reads(typeName.value.name, Reads[L](json => readL.value.reads(tagReads).reads(json)))
+      lazy val reads =
+        typeTagReads.reads(typeName.value.name, Reads[L](json => readL.value.reads.reads(json)))
           .map[FieldType[K, L] :+: R](l => Inl(field[K](l)))
-          .orElse(readR.value.reads(tagReads).map(r => Inr(r)))
-  }
+          .orElse(readR.value.reads.map(r => Inr(r)))
+    }
 
   implicit val readsHNil: DerivedReads[HNil] =
     new DerivedReads[HNil] {
-      def reads(tagReads: TypeTagReads) = Reads.pure[HNil](HNil)
+      val reads = Reads.pure[HNil](HNil)
     }
 
   implicit def readsLabelledHListOpt[K <: Symbol, H, T <: HList](implicit
@@ -40,12 +41,12 @@ trait DerivedReadsInstances extends DerivedReadsInstances1 {
     readT: Lazy[DerivedReads[T]]
   ): DerivedReads[FieldType[K, Option[H]] :: T] =
     new DerivedReads[FieldType[K, Option[H]] :: T] {
-      def reads(tagReads: TypeTagReads) =
+      lazy val reads =
         Reads.applicative.apply(
           (__ \ fieldName.value.name).readNullable(readH.value).map {
             h => { (t: T) => field[K](h) :: t }
           },
-          readT.value.reads(tagReads)
+          readT.value.reads
         )
     }
 
@@ -59,12 +60,12 @@ trait DerivedReadsInstances1 extends DerivedReadsInstances2 {
     readT: Lazy[DerivedReads[T]]
   ): DerivedReads[FieldType[K, H] :: T] =
     new DerivedReads[FieldType[K, H] :: T] {
-      def reads(tagReads: TypeTagReads) =
+      lazy val reads =
         Reads.applicative.apply(
           (__ \ fieldName.value.name).read(readH.value).map {
             h => { (t: T) => field[K](h) :: t }
           },
-          readT.value.reads(tagReads)
+          readT.value.reads
         )
     }
 
@@ -77,7 +78,7 @@ trait DerivedReadsInstances2 {
     derivedReads: Lazy[DerivedReads[R]]
   ): DerivedReads[A] =
     new DerivedReads[A] {
-      def reads(tagReads: TypeTagReads) = derivedReads.value.reads(tagReads).map(gen.from)
+      lazy val reads = derivedReads.value.reads.map(gen.from)
     }
 
 }

--- a/src/main/scala/julienrf/json/derived/package.scala
+++ b/src/main/scala/julienrf/json/derived/package.scala
@@ -5,24 +5,11 @@ import shapeless.Lazy
 
 package object derived {
 
-  def reads[A](implicit derivedReads: Lazy[DerivedReads[A]]): Reads[A] = derivedReads.value.reads(TypeTagReads.nested)
+  def reads[A](implicit derivedReads: Lazy[DerivedReads[A]]): Reads[A] = derivedReads.value.reads
 
-  def owrites[A](implicit derivedOWrites: Lazy[DerivedOWrites[A]]): OWrites[A] = derivedOWrites.value.owrites(TypeTagOWrites.nested)
+  def owrites[A](implicit derivedOWrites: Lazy[DerivedOWrites[A]]): OWrites[A] = derivedOWrites.value.owrites
 
   def oformat[A](implicit derivedReads: Lazy[DerivedReads[A]], derivedOWrites: Lazy[DerivedOWrites[A]]): OFormat[A] =
-    OFormat(derivedReads.value.reads(TypeTagReads.nested), derivedOWrites.value.owrites(TypeTagOWrites.nested))
-
-  object flat {
-
-    def reads[A](typeName: Reads[String])(implicit derivedReads: Lazy[DerivedReads[A]]): Reads[A] =
-      derivedReads.value.reads(TypeTagReads.flat(typeName))
-
-    def owrites[A](typeName: OWrites[String])(implicit derivedOWrites: Lazy[DerivedOWrites[A]]): OWrites[A] =
-      derivedOWrites.value.owrites(TypeTagOWrites.flat(typeName))
-
-    def oformat[A](typeName: OFormat[String])(implicit derivedReads: Lazy[DerivedReads[A]], derivedOWrites: Lazy[DerivedOWrites[A]]): OFormat[A] =
-      OFormat(derivedReads.value.reads(TypeTagReads.flat(typeName)), derivedOWrites.value.owrites(TypeTagOWrites.flat(typeName)))
-
-  }
+    OFormat(derivedReads.value.reads, derivedOWrites.value.owrites)
 
 }

--- a/src/test/scala/julienrf/json/derived/DerivedOFormatSuite.scala
+++ b/src/test/scala/julienrf/json/derived/DerivedOFormatSuite.scala
@@ -45,7 +45,8 @@ class DerivedOFormatSuite extends FeatureSpec with Checkers {
         identityLaw[Foo]
       }
       {
-        implicit val fooFormat: OFormat[Foo] = flat.oformat((__ \ "type").format[String])
+        import FlatFormat._
+        implicit val fooFormat: OFormat[Foo] = oformat
         identityLaw[Foo]
       }
     }
@@ -74,7 +75,8 @@ class DerivedOFormatSuite extends FeatureSpec with Checkers {
         identityLaw[Tree]
       }
       {
-        implicit lazy val treeFormat: OFormat[Tree] = flat.oformat((__ \ "$type").format[String])
+        import FlatFormat._
+        implicit lazy val treeFormat: OFormat[Tree] = oformat
         identityLaw[Tree]
       }
     }
@@ -100,10 +102,11 @@ class DerivedOFormatSuite extends FeatureSpec with Checkers {
   }
 
   feature("sum types JSON representation can be customized") {
+    import FlatFormat._
     sealed trait Foo
     case class Bar(x: Int) extends Foo
     case class Baz(s: String) extends Foo
-    val fooFlatFormat: OFormat[Foo] = flat.oformat((__ \ "type").format[String])
+    val fooFlatFormat: OFormat[Foo] = oformat
     assert(fooFlatFormat.writes(Bar(42)) == Json.obj("type" -> "Bar", "x" -> JsNumber(42)))
   }
 
@@ -139,3 +142,8 @@ class DerivedOFormatSuite extends FeatureSpec with Checkers {
   }
 
 }
+
+object FlatFormat extends FlatTypeTagOFormat {
+  val tagOFormat: OFormat[String] = (__ \ "type").format
+}
+


### PR DESCRIPTION
This PR changes the way the derived marshallers can be configured.

Before, the PR, a `DerivedReads[A]` had a method `def reads(typeTagReads: TypeTagReads): Reads[A]` that was using the `typeTagReads` parameter to customize the resulting `Reads[A]`.

With this PR, the configuration is retrieved from implicit parameters, during the derivation process. This makes it possible to use type-directed mechanisms for configuring field names, as in #33. With the previous design, this was harder to achieve with the same efficiency.

However, I still think that the design proposed by this PR has some drawbacks:
- The configuration is driven by implicits, meaning that the same line of code will behave differently, according to what is in the implicit scope ;
- We have to take care to use unique names for values that have to be explicitly imported ;
- If you forget to import your custom configuration nothing will help you to notice it (no compile error).

The first point is the one that bothers me the most. The last point could be solved by _not_ having a default configuration: users would be forced to import one configuration for their code to compile, and, if two configurations were imported, that would result in an ambiguous implicit values error.
