### PR TITLE
Fix dropping of error messages for sum types

### DIFF
--- a/src/main/scala/julienrf/json/derived/DerivedReads.scala
+++ b/src/main/scala/julienrf/json/derived/DerivedReads.scala
@@ -33,9 +33,10 @@ trait DerivedReadsInstances extends DerivedReadsInstances1 {
     new DerivedReads[FieldType[K, L] :+: R] {
       def reads(tagReads: TypeTagReads, adapter: NameAdapter) = {
         lazy val derivedReadL = readL.value.reads(tagReads, adapter)
-        tagReads.reads(typeName.value.name, Reads[L](json => derivedReadL.reads(json)))
-          .map[FieldType[K, L] :+: R](l => {Inl(field[K](l))})
-          .orElse(readR.value.reads(tagReads, adapter).map(r => Inr(r)))
+        Reads.alternative.|(
+          tagReads.reads(typeName.value.name, Reads[L](json => derivedReadL.reads(json)))
+            .map[FieldType[K, L] :+: R](l => {Inl(field[K](l))}),
+          readR.value.reads(tagReads, adapter).map(r => Inr(r)))
       }
   }
 

--- a/src/test/scala/julienrf/json/derived/DerivedOFormatSuite.scala
+++ b/src/test/scala/julienrf/json/derived/DerivedOFormatSuite.scala
@@ -138,4 +138,17 @@ class DerivedOFormatSuite extends FeatureSpec with Checkers {
     }
   }
 
+  feature("error messages must be helpful") {
+    sealed trait Foo
+    case class Bar(x: Int) extends Foo
+    case class Baz(s: String) extends Foo
+    val fooFlatFormat: OFormat[Foo] = flat.oformat((__ \ "type").format[String])
+    val readResult = fooFlatFormat.reads(Json.parse("""{"type": "Bar", "x": "string"}"""))
+    val errorString = readResult.fold(
+      _ flatMap { case (path, errors) =>
+		  errors.map(_.message + (if (path != __) " at " + path.toString else "")) } mkString ("; "),
+      _ => "No Errors")
+    assert(errorString == "error.sealed.trait; error.expected.jsnumber at /x")
+  }
+
 }


### PR DESCRIPTION
This PR resolved an issue I noted in https://github.com/julienrf/play-json-derived-codecs/issues/43 where all error messages are dropped except for `error.sealed.trait` at the path `__`.