### PR TITLE
updated to latest minor versions of sbt, scala, scalajs and other dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,21 @@
-scalaVersion in ThisBuild := "2.12.2"
+import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
-crossScalaVersions in ThisBuild := Seq(scalaVersion.value, "2.11.11")
+scalaVersion in ThisBuild := "2.12.6"
+
+crossScalaVersions in ThisBuild := Seq(scalaVersion.value, "2.11.12")
 
 val library =
-  crossProject.crossType(CrossType.Pure)
+  crossProject(JSPlatform, JVMPlatform)
+    .crossType(CrossType.Pure)
     .enablePlugins(GitVersioning)
     .settings(
       organization := "org.julienrf",
       name := "play-json-derived-codecs",
       libraryDependencies ++= Seq(
-        "com.chuusai" %%% "shapeless" % "2.3.2",
-        "org.scalatest" %%% "scalatest" % "3.0.3" % Test,
+        "com.chuusai" %%% "shapeless" % "2.3.3",
+        "org.scalatest" %%% "scalatest" % "3.0.5" % Test,
         "org.scalacheck" %%% "scalacheck" % "1.13.5" % Test,
-        "com.typesafe.play" %%% "play-json" % "2.6.1"
+        "com.typesafe.play" %%% "play-json" % "2.6.9"
       ),
       publishTo := {
         val nexus = "https://oss.sonatype.org"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,7 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.4")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.5.0")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.24")


### PR DESCRIPTION
The latest version of ScalaJS (0.6.24) is incompatible with the version `play-json-derived-codecs` uses (0.6.18), so I updated ScalaJS to the latest version. In addition, I updated SBT, Scala, and the other dependencies to their latest minor versions.