### PR TITLE
update README with declaration of custom formatters for selected types

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ In case you need even more control, you can still implement your own `TypeTagOWr
 
 ### Custom format for certain types in hierarchy
 
-Sometimes, you might want to represent one type differently than default format would. This can be done by creating an instance of `DerivedReads` or `DerivedWrites` for said type. Below is an example of implementing both custom reads and writes for a single class in a hierarchy:
+Sometimes, you might want to represent one type differently than default format would. This can be done by creating an implicit instance of `DerivedReads` or `DerivedWrites` for said type. Below is an example of implementing both custom reads and writes for a single class in a hierarchy:
 
 ~~~ scala
 sealed trait Hierarchy

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ case class First(x: Integer)
 case class Second(y: Integer)
 
 implicit val SecondReads: DerivedReads[Second] = new DerivedReads[Second] {
-  def reads(tagReads: TypeTagReads, adapter: NameAdapter) = (__ \ "foo").read[Integer].map(foo => Second(foo))
+  def reads(tagReads: TypeTagReads, adapter: NameAdapter) = tagReads.reads("Second", (__ \ "foo").read[Integer].map(foo => Second(foo)))
 }
 
 implicit val SecondWrites: DerivedOWrites[Second] = new DerivedOWrites[Second] {

--- a/README.md
+++ b/README.md
@@ -84,6 +84,25 @@ implicit val fooOWrites: OWrites[Foo] =
 
 In case you need even more control, you can still implement your own `TypeTagOWrites` and `TypeTagReads`.
 
+### Custom format for certain types in hierarchy
+
+Sometimes, you might want to represent one type differently than default format would. This can be done by creating an instance of `DerivedReads` or `DerivedWrites` for said type:
+
+~~~ scala
+sealed trait Hierarchy
+case class First(x: Integer)
+case class Second(y: String)
+
+implicit val SecondReads: DerivedReads[Second] = new DerivedReads[Second] {
+  def reads(tagReads: TypeTagReads, adapter: NameAdapter) = (__ \ "foo").read[Integer].map(foo => Second(foo.toString))
+}
+
+val defaultTypeFormat = (__ \ "type").format[String]
+implicit val HierarchyFormat = derived.flat.oformat[Hierarchy](defaultTypeFormat)
+~~~
+
+This will cause `Second` to be read with `SecondReads`, while the writes will remain automatically generated.
+
 ## Contributors
 
 See [here](https://github.com/julienrf/play-json-variants/graphs/contributors).

--- a/README.md
+++ b/README.md
@@ -86,22 +86,30 @@ In case you need even more control, you can still implement your own `TypeTagOWr
 
 ### Custom format for certain types in hierarchy
 
-Sometimes, you might want to represent one type differently than default format would. This can be done by creating an instance of `DerivedReads` or `DerivedWrites` for said type:
+Sometimes, you might want to represent one type differently than default format would. This can be done by creating an instance of `DerivedReads` or `DerivedWrites` for said type. Below is an example of implementing both custom reads and writes for a single class in a hierarchy:
 
 ~~~ scala
 sealed trait Hierarchy
 case class First(x: Integer)
-case class Second(y: String)
+case class Second(y: Integer)
 
 implicit val SecondReads: DerivedReads[Second] = new DerivedReads[Second] {
-  def reads(tagReads: TypeTagReads, adapter: NameAdapter) = (__ \ "foo").read[Integer].map(foo => Second(foo.toString))
+  def reads(tagReads: TypeTagReads, adapter: NameAdapter) = (__ \ "foo").read[Integer].map(foo => Second(foo))
+}
+
+implicit val SecondWrites: DerivedOWrites[Second] = new DerivedOWrites[Second] {
+  override def owrites(tagOwrites: TypeTagOWrites, adapter: NameAdapter): OWrites[Second] =
+    tagOwrites.owrites[Second](
+      "Second",
+      OWrites[Second](s => JsObject(("foo", Json.toJson(s.y)) :: Nil))
+    )
 }
 
 val defaultTypeFormat = (__ \ "type").format[String]
 implicit val HierarchyFormat = derived.flat.oformat[Hierarchy](defaultTypeFormat)
 ~~~
 
-This will cause `Second` to be read with `SecondReads`, while the writes will remain automatically generated.
+This will cause `Second` to be read with `SecondReads`, and read with `SecondWrites`.
 
 ## Contributors
 


### PR DESCRIPTION
I've added an example of how to create a custom formats for selected types in hierarchy to the README. This functionality was introduced in #20, but no example was present in the README before.