### PR TITLE
Make type tag derivation configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,18 @@ The default JSON representation of `Bar("quux", 42)` is the following JSON objec
 }
 ~~~
 
-### Custom Representation of Sum Types
+### Configuring the Derivation Process
+
+Three aspects of the derivation process can be configured:
+
+- the representation of sum types,
+- the way case class field names are mapped to JSON property names,
+- the type name used to discriminate sum types.
+
+#### Custom Representation of Sum Types
 
 The default representation of sum types may not fit all use cases. For instance, it is not very
-practical for enumerations. For this reason, the way sum types are represented is extensible.
+practical for enumerations.
 
 For instance, you might want to represent the `Bar("quux", 42)` value as the following JSON object:
 
@@ -82,7 +90,36 @@ implicit val fooOWrites: OWrites[Foo] =
   derived.flat.owrites((__ \ "type").write[String])
 ~~~
 
-In case you need even more control, you can still implement your own `TypeTagOWrites` and `TypeTagReads`.
+In case you need even more control, you can implement your own `TypeTagOWrites` and `TypeTagReads`.
+
+#### Custom Field Names Mapping
+
+By default, case class fields are mapped to JSON object properties having the same name.
+
+You can transform this mapping by supplying a different `NameAdapter` parameter. For
+instance, to use “snake case” in JSON:
+
+~~~ scala
+implicit val userFormat: OFormat[User] = derived.oformat(adapter = NameAdapter.snakeCase)
+~~~
+
+#### Custom Type Names
+
+By default, case class names are used as discriminators (type tags) for sum types.
+
+You can configure the type tags to use by using the `derived.withTypeTag` object:
+
+~~~ scala
+implicit val fooFormat: OFormat[Foo] =
+  derived.withTypeTag.oformat(TypeTagSetting.FullClassName)
+~~~
+
+The library provides the following `TypeTagSetting` values out of the box:
+
+- `TypeTagSetting.ShortClassName`: use the class name (as it is defined in Scala)
+- `TypeTagSetting.FullClassName`: use the fully qualified name
+- `TypeTagSetting.UserDefinedName`: require the presence of an implicit `CustomTypeTag[A]`
+  for all type `A` of the sum type, providing the type tag to use
 
 ### Custom format for certain types in hierarchy
 

--- a/library/src/main/scala/julienrf/json/derived/DerivedReads.scala
+++ b/library/src/main/scala/julienrf/json/derived/DerivedReads.scala
@@ -6,8 +6,10 @@ import shapeless.{::, HList, HNil, LabelledGeneric, Lazy, Witness, Coproduct, :+
 
 /**
   * Derives a `Reads[A]`
+  *
+  * @tparam TT Type of TypeTag to use to discriminate alternatives of sealed traits
   */
-trait DerivedReads[A] {
+trait DerivedReads[A, TT[A] <: TypeTag[A]] {
   /**
     * @param tagReads The strategy to use to deserialize sum types
     * @param adapter Fields naming strategy
@@ -20,37 +22,37 @@ object DerivedReads extends DerivedReadsInstances
 
 trait DerivedReadsInstances extends DerivedReadsInstances1 {
 
-  implicit val readsCNil: DerivedReads[CNil] =
-    new DerivedReads[CNil] {
+  implicit def readsCNil[TT[A] <: TypeTag[A]]: DerivedReads[CNil, TT] =
+    new DerivedReads[CNil, TT] {
       def reads(tagReads: TypeTagReads, adapter: NameAdapter) = Reads[CNil] { _ => JsError("error.sealed.trait") }
     }
 
-  implicit def readsCoProduct[K <: Symbol, L, R <: Coproduct](implicit
-    typeName: Witness.Aux[K],
-    readL: Lazy[DerivedReads[L]],
-    readR: Lazy[DerivedReads[R]]
-  ): DerivedReads[FieldType[K, L] :+: R] =
-    new DerivedReads[FieldType[K, L] :+: R] {
+  implicit def readsCoProduct[K <: Symbol, L, R <: Coproduct, TT[A] <: TypeTag[A]](implicit
+    readL: Lazy[DerivedReads[L, TT]],
+    readR: Lazy[DerivedReads[R, TT]],
+    typeTag: TT[FieldType[K, L]]
+  ): DerivedReads[FieldType[K, L] :+: R, TT] =
+    new DerivedReads[FieldType[K, L] :+: R, TT] {
       def reads(tagReads: TypeTagReads, adapter: NameAdapter) = {
         lazy val derivedReadL = readL.value.reads(tagReads, adapter)
         Reads.alternative.|(
-          tagReads.reads(typeName.value.name, Reads[L](json => derivedReadL.reads(json)))
+          tagReads.reads(typeTag.value, Reads[L](json => derivedReadL.reads(json)))
             .map[FieldType[K, L] :+: R](l => {Inl(field[K](l))}),
           readR.value.reads(tagReads, adapter).map(r => Inr(r)))
       }
   }
 
-  implicit val readsHNil: DerivedReads[HNil] =
-    new DerivedReads[HNil] {
+  implicit def readsHNil[TT[A] <: TypeTag[A]]: DerivedReads[HNil, TT] =
+    new DerivedReads[HNil, TT] {
       def reads(tagReads: TypeTagReads, adapter: NameAdapter) = Reads.pure[HNil](HNil)
     }
 
-  implicit def readsLabelledHListOpt[K <: Symbol, H, T <: HList](implicit
+  implicit def readsLabelledHListOpt[K <: Symbol, H, T <: HList, TT[A] <: TypeTag[A]](implicit
     fieldName: Witness.Aux[K],
     readH: Lazy[Reads[H]],
-    readT: Lazy[DerivedReads[T]]
-  ): DerivedReads[FieldType[K, Option[H]] :: T] =
-    new DerivedReads[FieldType[K, Option[H]] :: T] {
+    readT: Lazy[DerivedReads[T, TT]]
+  ): DerivedReads[FieldType[K, Option[H]] :: T, TT] =
+    new DerivedReads[FieldType[K, Option[H]] :: T, TT] {
       def reads(tagReads: TypeTagReads, adapter: NameAdapter) =
         Reads.applicative.apply(
           (__ \ adapter(fieldName.value.name)).readNullable(readH.value).map {
@@ -64,12 +66,12 @@ trait DerivedReadsInstances extends DerivedReadsInstances1 {
 
 trait DerivedReadsInstances1 extends DerivedReadsInstances2 {
 
-  implicit def readsLabelledHList[K <: Symbol, H, T <: HList](implicit
+  implicit def readsLabelledHList[K <: Symbol, H, T <: HList, TT[A] <: TypeTag[A]](implicit
     fieldName: Witness.Aux[K],
     readH: Lazy[Reads[H]],
-    readT: Lazy[DerivedReads[T]]
-  ): DerivedReads[FieldType[K, H] :: T] =
-    new DerivedReads[FieldType[K, H] :: T] {
+    readT: Lazy[DerivedReads[T, TT]]
+  ): DerivedReads[FieldType[K, H] :: T, TT] =
+    new DerivedReads[FieldType[K, H] :: T, TT] {
       def reads(tagReads: TypeTagReads, adapter: NameAdapter): Reads[FieldType[K, H] :: T] =
         Reads.applicative.apply(
           (__ \ adapter(fieldName.value.name)).read(readH.value).map {
@@ -83,11 +85,11 @@ trait DerivedReadsInstances1 extends DerivedReadsInstances2 {
 
 trait DerivedReadsInstances2 {
 
-  implicit def readsGeneric[A, R](implicit
+  implicit def readsGeneric[A, R, TT[A] <: TypeTag[A]](implicit
     gen: LabelledGeneric.Aux[A, R],
-    derivedReads: Lazy[DerivedReads[R]]
-  ): DerivedReads[A] =
-    new DerivedReads[A] {
+    derivedReads: Lazy[DerivedReads[R, TT]]
+  ): DerivedReads[A, TT] =
+    new DerivedReads[A, TT] {
       def reads(tagReads: TypeTagReads, adapter: NameAdapter) = derivedReads.value.reads(tagReads, adapter).map(gen.from)
     }
 

--- a/library/src/main/scala/julienrf/json/derived/package.scala
+++ b/library/src/main/scala/julienrf/json/derived/package.scala
@@ -5,23 +5,100 @@ import shapeless.Lazy
 
 package object derived {
 
-  def reads[A](adapter: NameAdapter = NameAdapter.identity)(implicit derivedReads: Lazy[DerivedReads[A]]): Reads[A] = derivedReads.value.reads(TypeTagReads.nested, adapter)
+  def reads[A](
+    adapter: NameAdapter = NameAdapter.identity
+  )(implicit
+    derivedReads: Lazy[DerivedReads[A, TypeTag.ShortClassName]]
+  ): Reads[A] =
+    derivedReads.value.reads(TypeTagReads.nested, adapter)
 
-  def owrites[A](adapter: NameAdapter = NameAdapter.identity)(implicit derivedOWrites: Lazy[DerivedOWrites[A]]): OWrites[A] = derivedOWrites.value.owrites(TypeTagOWrites.nested, adapter)
+  def owrites[A](
+    adapter: NameAdapter = NameAdapter.identity
+  )(implicit
+    derivedOWrites: Lazy[DerivedOWrites[A, TypeTag.ShortClassName]]
+  ): OWrites[A] =
+    derivedOWrites.value.owrites(TypeTagOWrites.nested, adapter)
 
-  def oformat[A](adapter: NameAdapter = NameAdapter.identity)(implicit derivedReads: Lazy[DerivedReads[A]], derivedOWrites: Lazy[DerivedOWrites[A]]): OFormat[A] =
+  def oformat[A](
+    adapter: NameAdapter = NameAdapter.identity
+  )(implicit
+    derivedReads: Lazy[DerivedReads[A, TypeTag.ShortClassName]],
+    derivedOWrites: Lazy[DerivedOWrites[A, TypeTag.ShortClassName]]
+  ): OFormat[A] =
     OFormat(derivedReads.value.reads(TypeTagReads.nested, adapter), derivedOWrites.value.owrites(TypeTagOWrites.nested, adapter))
 
   object flat {
 
-    def reads[A](typeName: Reads[String], adapter: NameAdapter = NameAdapter.identity)(implicit derivedReads: Lazy[DerivedReads[A]]): Reads[A] =
+    def reads[A](
+      typeName: Reads[String],
+      adapter: NameAdapter = NameAdapter.identity
+    )(implicit
+      derivedReads: Lazy[DerivedReads[A, TypeTag.ShortClassName]]
+    ): Reads[A] =
       derivedReads.value.reads(TypeTagReads.flat(typeName), adapter)
 
-    def owrites[A](typeName: OWrites[String], adapter: NameAdapter = NameAdapter.identity)(implicit derivedOWrites: Lazy[DerivedOWrites[A]]): OWrites[A] =
+    def owrites[A](
+      typeName: OWrites[String],
+      adapter: NameAdapter = NameAdapter.identity,
+    )(implicit
+      derivedOWrites: Lazy[DerivedOWrites[A, TypeTag.ShortClassName]]
+    ): OWrites[A] =
       derivedOWrites.value.owrites(TypeTagOWrites.flat(typeName), adapter)
 
-    def oformat[A](typeName: OFormat[String], adapter: NameAdapter = NameAdapter.identity)(implicit derivedReads: Lazy[DerivedReads[A]], derivedOWrites: Lazy[DerivedOWrites[A]]): OFormat[A] =
+    def oformat[A](
+      typeName: OFormat[String],
+      adapter: NameAdapter = NameAdapter.identity
+    )(implicit
+      derivedReads: Lazy[DerivedReads[A, TypeTag.ShortClassName]],
+      derivedOWrites: Lazy[DerivedOWrites[A, TypeTag.ShortClassName]]
+    ): OFormat[A] =
       OFormat(derivedReads.value.reads(TypeTagReads.flat(typeName), adapter), derivedOWrites.value.owrites(TypeTagOWrites.flat(typeName), adapter))
+
+  }
+
+  // Ideally, we would just have a `typeTagSetting: TypeTagSetting` parameter
+  // in the previous methods, with a default value of `TypeTagSetting.ShortClassName`.
+  // However, this is not supported by Scala 2 (see https://github.com/scala/bug/issues/11571).
+  object withTypeTag {
+
+    /** Derives a `Reads[A]` instance, using the given `typeTagSetting`, `adapter`,
+      * and `typeTagReads` configuration.
+      */
+    def reads[A](
+      typeTagSetting: TypeTagSetting,
+      adapter: NameAdapter = NameAdapter.identity,
+      typeTagReads: TypeTagReads = TypeTagReads.nested
+    )(implicit
+      derivedReads: Lazy[DerivedReads[A, typeTagSetting.Value]]
+    ): Reads[A] =
+      derivedReads.value.reads(typeTagReads, adapter)
+
+    /**
+      * Derives an `OWrites[A]` instance, using the given `typeTagSetting`, `adapter`,
+      * and `typeTagOWrites` configuration.
+      */
+    def owrites[A](
+      typeTagSetting: TypeTagSetting,
+      adapter: NameAdapter = NameAdapter.identity,
+      typeTagOWrites: TypeTagOWrites = TypeTagOWrites.nested
+    )(implicit
+      derivedOWrites: Lazy[DerivedOWrites[A, typeTagSetting.Value]]
+    ): OWrites[A] =
+      derivedOWrites.value.owrites(typeTagOWrites, adapter)
+
+    /**
+      * Derives an `OFormat[A]` instance, using the given `typeTagSetting`, `adapter`,
+      * and `typeTagOFormat` configuration.
+      */
+    def oformat[A](
+      typeTagSetting: TypeTagSetting,
+      adapter: NameAdapter = NameAdapter.identity,
+      typeTagOFormat: TypeTagOFormat = TypeTagOFormat.nested
+    )(implicit
+      derivedReads: Lazy[DerivedReads[A, typeTagSetting.Value]],
+      derivedOWrites: Lazy[DerivedOWrites[A, typeTagSetting.Value]]
+    ): OFormat[A] =
+      OFormat(derivedReads.value.reads(typeTagOFormat, adapter), derivedOWrites.value.owrites(typeTagOFormat, adapter))
 
   }
 


### PR DESCRIPTION
Introduce `TypeTag` type class, providing a way to obtain the type tag to use for a given type.

Fixes #41