### PR TITLE
Adding support for picking up user-defined `OFormat`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,32 @@ implicit val HierarchyFormat = derived.flat.oformat[Hierarchy](defaultTypeFormat
 
 This will cause `Second` to be read with `SecondReads`, and read with `SecondWrites`.
 
+### Avoiding redundant derivation
+
+By default, the auto-derivation mechanism will be applied to the whole sealed hierarchy. This might be costly in terms of compile-time (as Shapeless is being used under the hood).
+To avoid this, it is possible to define an `OFormat` for the different cases, thus only using auto-derivation for the branching in the sealed trait and nothing else.
+~~~ scala
+sealed trait Hierarchy
+case class First(a: Int, b: Int, c: Int)
+case class Second(x: Int, y: Int, c: Int)
+
+object First {
+  implicit val format: OFormat[First] = Json.format
+}
+
+object Second {
+  implicit val format: OFormat[Second] = Json.format
+}
+
+implicit val HierarchyFormat = derived.oformat[Hierarchy]
+~~~
+
+Note: it's important that the provided `Format`s are of the specific `OFormat` sub-type, otherwise, they won't be picked up by the implicit machinery.
+
+Without the provided `Format`s the derivation mechanism will traverse all the fields in the hierarchy (in this case 6 in total), which may be costly for larger case classes.
+
+Providing the implicits this way can also be used for customization without having to deal with supplying your own type-tags.
+
 ## Contributors
 
 See [here](https://github.com/julienrf/play-json-variants/graphs/contributors).

--- a/library/src/main/scala/julienrf/json/derived/DerivedReads.scala
+++ b/library/src/main/scala/julienrf/json/derived/DerivedReads.scala
@@ -21,6 +21,22 @@ trait DerivedReads[A, TT[A] <: TypeTag[A]] {
 object DerivedReads extends DerivedReadsInstances
 
 trait DerivedReadsInstances extends DerivedReadsInstances1 {
+  /** Supports reading a coproduct where the left branch already has a defined `Reads` instance.
+    * This will avoid using the `Generic` implicit for cases where it is possible to use a pre-existing
+    * `Reads`, thus enabling users to easily plug-in their own `Format` as well as saving on compile-times.
+    */
+  implicit def readPredefinedCoProduct[K <: Symbol, L, R <: Coproduct, TT[A] <: TypeTag[A]](implicit
+    readL: Lazy[Reads[L]],
+    readR: Lazy[DerivedReads[R, TT]],
+    typeTag: TT[FieldType[K, L]]
+  ): DerivedReads[FieldType[K, L] :+: R, TT] =
+    DerivedReadsUtil.makeCoProductReads(
+      (_, _) => readL,
+      readR,
+      typeTag)
+}
+
+trait DerivedReadsInstances1 extends DerivedReadsInstances2 {
 
   implicit def readsCNil[TT[A] <: TypeTag[A]]: DerivedReads[CNil, TT] =
     new DerivedReads[CNil, TT] {
@@ -32,15 +48,10 @@ trait DerivedReadsInstances extends DerivedReadsInstances1 {
     readR: Lazy[DerivedReads[R, TT]],
     typeTag: TT[FieldType[K, L]]
   ): DerivedReads[FieldType[K, L] :+: R, TT] =
-    new DerivedReads[FieldType[K, L] :+: R, TT] {
-      def reads(tagReads: TypeTagReads, adapter: NameAdapter) = {
-        lazy val derivedReadL = readL.value.reads(tagReads, adapter)
-        Reads.alternative.|(
-          tagReads.reads(typeTag.value, Reads[L](json => derivedReadL.reads(json)))
-            .map[FieldType[K, L] :+: R](l => {Inl(field[K](l))}),
-          readR.value.reads(tagReads, adapter).map(r => Inr(r)))
-      }
-  }
+    DerivedReadsUtil.makeCoProductReads(
+      (tagReads, adapter) => Lazy(readL.value.reads(tagReads, adapter)),
+      readR,
+      typeTag)
 
   implicit def readsHNil[TT[A] <: TypeTag[A]]: DerivedReads[HNil, TT] =
     new DerivedReads[HNil, TT] {
@@ -64,7 +75,7 @@ trait DerivedReadsInstances extends DerivedReadsInstances1 {
 
 }
 
-trait DerivedReadsInstances1 extends DerivedReadsInstances2 {
+trait DerivedReadsInstances2 extends DerivedReadsInstances3 {
 
   implicit def readsLabelledHList[K <: Symbol, H, T <: HList, TT[A] <: TypeTag[A]](implicit
     fieldName: Witness.Aux[K],
@@ -83,7 +94,7 @@ trait DerivedReadsInstances1 extends DerivedReadsInstances2 {
 
 }
 
-trait DerivedReadsInstances2 {
+trait DerivedReadsInstances3 {
 
   implicit def readsGeneric[A, R, TT[A] <: TypeTag[A]](implicit
     gen: LabelledGeneric.Aux[A, R],
@@ -93,4 +104,25 @@ trait DerivedReadsInstances2 {
       def reads(tagReads: TypeTagReads, adapter: NameAdapter) = derivedReads.value.reads(tagReads, adapter).map(gen.from)
     }
 
+}
+
+private[derived] object DerivedReadsUtil {
+  def makeCoProductReads[K <: Symbol, L, R <: Coproduct, TT[A] <: TypeTag[A]](
+    makeReadsL: (TypeTagReads, NameAdapter) => Lazy[Reads[L]],
+    readR: Lazy[DerivedReads[R, TT]],
+    typeTag: TT[FieldType[K, L]]
+  ): DerivedReads[FieldType[K, L] :+: R, TT] =
+    new DerivedReads[FieldType[K, L] :+: R, TT] {
+      def reads(tagReads: TypeTagReads, adapter: NameAdapter) = {
+        // we don't want to create the Reads instance more than once
+        val readsL = makeReadsL(tagReads, adapter)
+
+        Reads.alternative.|(
+          tagReads.reads(
+            typeTag.value,
+            Reads[L](json => readsL.value.reads(json)))
+            .map[FieldType[K, L] :+: R](l => {Inl(field[K](l))}),
+          readR.value.reads(tagReads, adapter).map(r => Inr(r)))
+      }
+    }
 }


### PR DESCRIPTION
Hi,

While using this library we stumbled on very high compile-times when deriving for hierarchies with large case classes. Digging into the issue showed that there's no way to avoid the derivation process even for classes that have their own `OFormat` already defined.

This pull request aims to fix that. The result should help saving on compile-times when deriving for hierarchies with many fields in the cases.

I've added a test and notes in the README that should illustrate how this is used.

Thanks