### PR TITLE
Adding support for using plain `Writes`/`Format` as custom implicits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ This will cause `Second` to be read with `SecondReads`, and read with `SecondWri
 ### Avoiding redundant derivation
 
 By default, the auto-derivation mechanism will be applied to the whole sealed hierarchy. This might be costly in terms of compile-time (as Shapeless is being used under the hood).
-To avoid this, it is possible to define an `OFormat` for the different cases, thus only using auto-derivation for the branching in the sealed trait and nothing else.
+To avoid this, it is possible to define a `Format` for the different cases, thus only using auto-derivation for the branching in the sealed trait and nothing else.
 ~~~ scala
 sealed trait Hierarchy
 case class First(a: Int, b: Int, c: Int)
@@ -168,7 +168,8 @@ object Second {
 implicit val HierarchyFormat = derived.oformat[Hierarchy]
 ~~~
 
-Note: it's important that the provided `Format`s are of the specific `OFormat` sub-type, otherwise, they won't be picked up by the implicit machinery.
+Note: in case `derived.flat` is being used, it's important that the provided `Format`s are of the specific `OFormat` sub-type, otherwise, they won't be picked up by the implicit machinery.
+For this reason, `Json.valueFormat` is not compatible with `derived.flat` and they should not be used together.
 
 Without the provided `Format`s the derivation mechanism will traverse all the fields in the hierarchy (in this case 6 in total), which may be costly for larger case classes.
 

--- a/library/src/main/scala/julienrf/json/derived/typetags.scala
+++ b/library/src/main/scala/julienrf/json/derived/typetags.scala
@@ -1,9 +1,8 @@
 package julienrf.json.derived
 
-import play.api.libs.json.{Json, OFormat, OWrites, Reads, __}
+import play.api.libs.json.{Json, OFormat, OWrites, Reads, Writes, __}
 import shapeless.Witness
 import shapeless.labelled.FieldType
-
 import scala.language.higherKinds
 import scala.reflect.ClassTag
 
@@ -13,15 +12,30 @@ import scala.reflect.ClassTag
   * Built-in instances live in the [[TypeTagOWrites$ companion object]].
   */
 trait TypeTagOWrites {
+  /** Stands for a sub-type of `Writes` that this type-tag can process.
+    *
+    * We need this since the flat format (see below), can only operate on `OWrites` instances.
+    * While the nested format (see below) can work with any `Writes` whatsoever.
+    *
+    * To support this distinction we can vary [[W]] so that it matches these limitations.
+    */
+  type W[A]
+
   /**
     * @param typeName Type name
-    * @param owrites Base serializer
+    * @param writes Base serializer
     * @return A serializer that encodes an `A` value along with its type tag
     */
-  def owrites[A](typeName: String, owrites: OWrites[A]): OWrites[A]
+  def owrites[A](typeName: String, writes: W[A]): OWrites[A]
 }
 
 object TypeTagOWrites {
+  type Aux[W0[_]] = TypeTagOWrites {
+    type W[A] = W0[A]
+  }
+
+  type Nested = Aux[Writes]
+  type Flat = Aux[OWrites]
 
   /**
     * Encodes a tagged type by creating a JSON object wrapping the actual `A` JSON representation. This wrapper
@@ -46,10 +60,12 @@ object TypeTagOWrites {
     *   }
     * }}}
     */
-  val nested: TypeTagOWrites =
+  val nested: TypeTagOWrites.Nested =
     new TypeTagOWrites {
-      def owrites[A](typeName: String, owrites: OWrites[A]): OWrites[A] =
-        OWrites[A](a => Json.obj(typeName -> owrites.writes(a)))
+      type W[A] = Writes[A]
+
+      def owrites[A](typeName: String, writes: Writes[A]): OWrites[A] =
+        OWrites[A](a => Json.obj(typeName -> writes.writes(a)))
     }
 
   /**
@@ -81,13 +97,13 @@ object TypeTagOWrites {
     *
     * @param tagOwrites A way to encode the type tag as a JSON object (whose fields will be merged with the base JSON representation)
     */
-  def flat(tagOwrites: OWrites[String]): TypeTagOWrites =
+  def flat(tagOwrites: OWrites[String]): TypeTagOWrites.Flat =
     new TypeTagOWrites {
+      type W[A] = OWrites[A]
+
       def owrites[A](typeName: String, owrites: OWrites[A]): OWrites[A] =
         OWrites[A](a => tagOwrites.writes(typeName) ++ owrites.writes(a))
     }
-
-
 }
 
 /**
@@ -132,18 +148,26 @@ object TypeTagReads {
 trait TypeTagOFormat extends TypeTagReads with TypeTagOWrites
 
 object TypeTagOFormat {
+  type Aux[W0[_]] = TypeTagOFormat {
+    type W[A] = W0[A]
+  }
 
-  def apply(ttReads: TypeTagReads, ttOWrites: TypeTagOWrites): TypeTagOFormat =
+  type Nested = Aux[Writes]
+  type Flat = Aux[OWrites]
+
+  def apply[W0[A] >: OWrites[A]](ttReads: TypeTagReads, ttOWrites: TypeTagOWrites.Aux[W0]): TypeTagOFormat.Aux[W0] =
     new TypeTagOFormat {
+      type W[A] = W0[A]
+
       def reads[A](typeName: String, reads: Reads[A]): Reads[A] = ttReads.reads(typeName, reads)
-      def owrites[A](typeName: String, owrites: OWrites[A]): OWrites[A] = ttOWrites.owrites(typeName, owrites)
+      def owrites[A](typeName: String, writes: W[A]): OWrites[A] = ttOWrites.owrites(typeName, writes)
     }
 
-  val nested: TypeTagOFormat =
-    TypeTagOFormat(TypeTagReads.nested, TypeTagOWrites.nested)
+  val nested: TypeTagOFormat.Nested =
+    TypeTagOFormat[Writes](TypeTagReads.nested, TypeTagOWrites.nested)
 
-  def flat(tagFormat: OFormat[String]): TypeTagOFormat =
-    TypeTagOFormat(TypeTagReads.flat(tagFormat), TypeTagOWrites.flat(tagFormat))
+  def flat(tagFormat: OFormat[String]): TypeTagOFormat.Flat =
+    TypeTagOFormat[OWrites](TypeTagReads.flat(tagFormat), TypeTagOWrites.flat(tagFormat))
 
 }
 


### PR DESCRIPTION
When using custom formats with the the `nested` format it's now possible to use any `Writes`/`Format`.

The `flat` format still requires an `OWrites`/`OFormat` type.

Partially addresses #76.

This change required duplicating the content of the `withTypeTag` object, so that now we have `withTypeTag.flat`. Hopefully, this change won't be noticed by most users (as using `withTypeTag` with non-default arguments is probably rare).