### PR TITLE
Fixing support for recursive ADTs and user-defined implicits

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
-import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
+import com.typesafe.tools.mima.core.{IncompatibleSignatureProblem, ProblemFilters}
+import sbtcrossproject.CrossPlugin.autoImport.{CrossType, crossProject}
 
 ThisBuild / organization := "org.julienrf"
 
@@ -9,6 +10,11 @@ ThisBuild / crossScalaVersions := Seq(scalaVersion.value, "2.12.8")
 ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
 // Temporary, because version 10.0.0 was invalid
 ThisBuild / versionPolicyPreviousVersions := Seq("10.0.1")
+
+ThisBuild / mimaBinaryIssueFilters ++= Seq(
+  // package private method
+  ProblemFilters.exclude[IncompatibleSignatureProblem]("julienrf.json.derived.DerivedOWritesUtil.makeCoProductOWrites")
+)
 
 ThisBuild / developers := List(
   Developer(

--- a/library/src/main/scala/julienrf/json/derived/DerivedOWrites.scala
+++ b/library/src/main/scala/julienrf/json/derived/DerivedOWrites.scala
@@ -32,7 +32,7 @@ trait DerivedOWritesInstances extends DerivedOWritesInstances1 {
     typeTag: TT[FieldType[K, L]]
   ): DerivedOWrites[FieldType[K, L] :+: R, TT] =
     DerivedOWritesUtil.makeCoProductOWrites(
-      (_, _) => writesL.value,
+      (_, _) => writesL,
       owritesR,
       typeTag)
 }
@@ -77,7 +77,7 @@ trait DerivedOWritesInstances1 extends DerivedOWritesInstances2 {
     typeTag: TT[FieldType[K, L]]
   ): DerivedOWrites[FieldType[K, L] :+: R, TT] =
     DerivedOWritesUtil.makeCoProductOWrites(
-      owritesL.value.owrites,
+      (tagOwrites, adapter) => owritesL.map(_.owrites(tagOwrites, adapter)),
       owritesR,
       typeTag)
 }
@@ -116,7 +116,7 @@ trait DerivedOWritesInstances3 {
 
 private[derived] object DerivedOWritesUtil {
   def makeCoProductOWrites[K <: Symbol, L, R <: Coproduct, TT[A] <: TypeTag[A]](
-    makeWritesL: (TypeTagOWrites, NameAdapter) => Writes[L],
+    makeWritesL: (TypeTagOWrites, NameAdapter) => Lazy[Writes[L]],
     owritesR: Lazy[DerivedOWrites[R, TT]],
     typeTag: TT[FieldType[K, L]]
   ): DerivedOWrites[FieldType[K, L] :+: R, TT] =
@@ -127,7 +127,7 @@ private[derived] object DerivedOWritesUtil {
         val derivedOwriteR = owritesR.value.owrites(tagOwrites, adapter)
 
         OWrites[FieldType[K, L] :+: R] {
-          case Inl(l) => tagOwrites.owrites(typeTag.value, writesL).writes(l)
+          case Inl(l) => tagOwrites.owrites(typeTag.value, writesL.value).writes(l)
           case Inr(r) => derivedOwriteR.writes(r)
         }
       }

--- a/library/src/main/scala/julienrf/json/derived/typetags.scala
+++ b/library/src/main/scala/julienrf/json/derived/typetags.scala
@@ -139,7 +139,6 @@ object TypeTagReads {
     *
     * @param tagReads A way to decode the type tag value.
     */
-  //TODO docs on edge case
   def flat(tagReads: Reads[String]): TypeTagReads =
     new TypeTagReads {
       def reads[A](typeName: String, reads: Reads[A]): Reads[A] = {


### PR DESCRIPTION
Apparently, the combination of user-defined implicits and recursive ADTs never worked. The code wasn't appropriately preserving laziness.

That is to say, 9.0.0 was also broken in that respect, it's just that it completely ignored user-defined `Format`s (as opposed to `OFormat`) values. As a result, the bug wasn't apparent since `derived` re-derived all of the formats on its own and that was sufficiently lazy. In 10.0.1 we started picking up user-defined implicits, and that revealed the bug.

Fixes #84.