### PR TITLE
Update play-json dependency to 3.x, update README. Fixes #91

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,17 @@ Compared to the built-in macros, this project brings support for:
 - recursive types ;
 - polymorphic types.
 
-The artifacts are built for Scala and Scala.js 2.12, and 2.13, Play 2.9 and Shapeless 2.3.
+The artifacts are built for Scala and Scala.js 2.12, and 2.13, Play 3.0 and Shapeless 2.3.
 
-For Play 2.8 compatibility see version [`7.0.0`](https://github.com/julienrf/play-json-derived-codecs/tree/v6.0.0).
+## Versions
+
+For previous versions of Play, you can use previous versions of this library:
+
+| Library version                                                             | Play version    |
+|-----------------------------------------------------------------------------|-----------------|
+| [Latest](https://github.com/julienrf/play-json-derived-codecs/releases)     | 3.0.x           |
+| [10.1.0](https://github.com/julienrf/play-json-derived-codecs/tree/v10.1.0) | 2.9.x           |
+| [7.0.0](https://github.com/julienrf/play-json-derived-codecs/tree/v7.0.0)   | 2.8.x           |
 
 ## Usage
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ val library =
         "org.scalatest" %%% "scalatest" % "3.2.3" % Test,
         "org.scalacheck" %%% "scalacheck" % "1.15.2" % Test,
         "org.scalatestplus" %%% "scalacheck-1-15" % "3.2.3.0" % Test,
-        "com.typesafe.play" %%% "play-json" % "2.9.2"
+        "org.playframework" %%% "play-json" % "3.0.1"
       ),
       scalacOptions ++= {
         Seq(


### PR DESCRIPTION
Adds support for play-json 3.0 with the new groupId on the dependency.

Fixes #91 