### PR TITLE
Update play-json dependency to 3.x, update README. Fixes #91

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: coursier/cache-action@v5
-      - uses: olafurpg/setup-scala@v10
+      - uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
       - run: git fetch --unshallow
       - run: sbt +test libraryJVM/versionPolicyCheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: olafurpg/setup-scala@v10
+      - uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
       - uses: coursier/cache-action@v5
       - run: git fetch --unshallow
       - run: sbt versionCheck ci-release

--- a/README.md
+++ b/README.md
@@ -10,9 +10,17 @@ Compared to the built-in macros, this project brings support for:
 - recursive types ;
 - polymorphic types.
 
-The artifacts are built for Scala and Scala.js 2.12, and 2.13, Play 2.9 and Shapeless 2.3.
+The artifacts are built for Scala and Scala.js 2.12, and 2.13, Play 3.0 and Shapeless 2.3.
 
-For Play 2.8 compatibility see version [`7.0.0`](https://github.com/julienrf/play-json-derived-codecs/tree/v6.0.0).
+## Versions
+
+For previous versions of Play, you can use previous versions of this library:
+
+| Library version                                                             | Play version    |
+|-----------------------------------------------------------------------------|-----------------|
+| [Latest](https://github.com/julienrf/play-json-derived-codecs/releases)     | 3.0.x           |
+| [10.1.0](https://github.com/julienrf/play-json-derived-codecs/tree/v10.1.0) | 2.9.x           |
+| [7.0.0](https://github.com/julienrf/play-json-derived-codecs/tree/v7.0.0)   | 2.8.x           |
 
 ## Usage
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ val library =
         "org.scalatest" %%% "scalatest" % "3.2.3" % Test,
         "org.scalacheck" %%% "scalacheck" % "1.15.2" % Test,
         "org.scalatestplus" %%% "scalacheck-1-15" % "3.2.3.0" % Test,
-        "com.typesafe.play" %%% "play-json" % "2.9.2"
+        "org.playframework" %%% "play-json" % "3.0.1"
       ),
       scalacOptions ++= {
         Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ ThisBuild / scalaVersion := "2.13.3"
 
 ThisBuild / crossScalaVersions := Seq(scalaVersion.value, "2.12.8")
 
-ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
+ThisBuild / versionPolicyIntention := Compatibility.None
 
 ThisBuild / mimaBinaryIssueFilters ++= Seq(
   // package private method

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.5.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
 
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
 


### PR DESCRIPTION
Adds support for play-json 3.0 with the new groupId on the dependency.

Fixes https://github.com/julienrf/play-json-derived-codecs/issues/91

NB- this is @matmannion's work (https://github.com/julienrf/play-json-derived-codecs/pull/92) with the CI fixes suggested by @julienrf 